### PR TITLE
A bit Pax nerf

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -67,7 +67,7 @@
     solution: melee
   - type: SolutionInjectOnCollide
     transferAmount: 5
-    blockSlots: NONE
+    blockSlots: OuterClothing #Imperial balance pax nerf
   - type: SolutionTransfer
     maxTransferAmount: 5
   - type: Wieldable

--- a/Resources/Prototypes/Imperial/Psychosis/reagents.yml
+++ b/Resources/Prototypes/Imperial/Psychosis/reagents.yml
@@ -8,6 +8,7 @@
   color: "#AAAAAA"
   metabolisms:
     Poison:
+      metabolismRate: 0.33 #Imperial balance.
       effects:
       - !type:HealthChange
         damage:
@@ -20,6 +21,9 @@
         - !type:ReagentThreshold
           min: 9
       - !type:GenericStatusEffect
+        conditions: #Imperial balance
+        - !type:ReagentThreshold #///
+          min: 4 #Imperial balance END
         key: Pacified
         component: Pacified
         refresh: false

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -516,8 +516,12 @@
   color: "#AAAAAA"
   metabolisms:
     Poison:
+      metabolismRate: 0.33 #Imperial balance
       effects:
       - !type:GenericStatusEffect
+        conditions: #Imperial balance
+        - !type:ReagentThreshold #///
+          min: 5 #Imperial balance END
         key: Pacified
         component: Pacified
         refresh: false


### PR DESCRIPTION
О работе:
Добавляет паксу и его улучшенной версии минимальное требование по количеству для активации способности "Пацифизм".
Яд с наконечников копий при броске не может проникнуть в тело, если в слоте внешней одежды (скафандра или бронижелета) есть что-нибудь. Не затрагивает обычные удары в ближнем бою.

Зачем?:
По многочисленным просьбам. И что бы прекратить длиннющее обсуждение, из-за которого у меня начала болеть голова.

Детали:
Если вколоть сразу 5 ед. пакса, эффект "Пафицизм" подействует где-то на 1 секунду, после чего спадёт. Если действующего вещества будет больше 5 ед. (например, 7 или 10), эффект пацифизма будет действовать всё это время. Если постоянно вкалывать по 1 ед. вещества, когда его меньше 5 ед, то не произойдёт ничего.
Так что игрокам на дедах всё ещё стоит опасаться хорошо сгруппированные отряды метких лучников. Косых лучников тоже следует опасаться, но меньше.

В качестве лёгкой балансировки, пакс усваивается чу-у-у-у-у-уточку медленнее.