### PR TITLE
Набор с АКМС в аплинке ядерных оперативников

### DIFF
--- a/Resources/Locale/ru-RU/Imperial/BundleAKMS/duffelbag.ftl
+++ b/Resources/Locale/ru-RU/Imperial/BundleAKMS/duffelbag.ftl
@@ -1,0 +1,3 @@
+ent-ClothingBackpackDuffelSyndicateAKMS = Набор АКМС
+    .desc = Классический АКМС, имеет четыре магазина внутри
+    .suffix = { "" }

--- a/Resources/Locale/ru-RU/Imperial/BundleAKMS/uplink-catalog.ftl
+++ b/Resources/Locale/ru-RU/Imperial/BundleAKMS/uplink-catalog.ftl
@@ -1,0 +1,4 @@
+
+# Bundles
+uplink-bundle-akms-name = {ent-ClothingBackpackDuffelSyndicateAKMS}
+uplink-bundle-akms-desc = {ent-ClothingBackpackDuffelSyndicateAKMS.desc}

--- a/Resources/Prototypes/Imperial/BundleAKMS/duffelbag.yml
+++ b/Resources/Prototypes/Imperial/BundleAKMS/duffelbag.yml
@@ -1,0 +1,12 @@
+
+- type: entity
+  parent: ClothingBackpackDuffelSyndicateBundle
+  id: ClothingBackpackDuffelSyndicateAKMS
+  name: AKMS bundle
+  description: "Old faithful: The classic AKMS, bundled with four magazines." 
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponRifleAk
+      - id: MagazineLightRifle
+        amount: 3

--- a/Resources/Prototypes/Imperial/BundleAKMS/uplink_catalog.yml
+++ b/Resources/Prototypes/Imperial/BundleAKMS/uplink_catalog.yml
@@ -1,0 +1,23 @@
+# TODO: make more categories
+
+# Bundles
+
+- type: listing
+  id: WeaponBundleAKMS
+  name: uplink-bundle-akms-name
+  description: uplink-bundle-akms-desc
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Rifles/ak.rsi, state: icon }
+  productEntity: ClothingBackpackDuffelSyndicateAKMS
+  cost:
+    Telecrystal: 23
+  categories:
+  - UplinkBundles
+  conditions:
+   - !type:StoreWhitelistCondition
+     whitelist:
+      tags:
+         - NukeOpsUplink
+   - !type:BuyerWhitelistCondition
+      blacklist:
+      components:
+      - SurplusBundle


### PR DESCRIPTION
## About the PR
Добавляет КРУТЕЙШИЙ!!! набор АКМС в аплинк ядерных оперативников, стоимость 23 ТК, в наборе имеется 3 запасных магазина на АКМС

## Why / Balance
Ядерным оперативным специалистам требуется оружие для дальних дистанций, исключающее возможность использования "Христова" из-за его низкой скорости стрельбы. Почему бы не предоставить им подходящее оружие для эффективного выполнения поставленных задач?