### PR TITLE
Fix Moth names

### DIFF
--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -8,9 +8,9 @@
   markingLimits: MobMothMarkingLimits
   dollPrototype: MobMothDummy
   skinColoration: Hues
-  maleFirstNames: names_moth_first_male
-  femaleFirstNames: names_moth_first_female
-  lastNames: names_moth_last
+  maleFirstNames: names_first_male
+  femaleFirstNames: names_first_female
+  lastNames: names_last
 
 - type: speciesBaseSprites
   id: MobMothSprites


### PR DESCRIPTION
Изменён путь для генератора имён моли. Теперь никаких имён, написанных на латинице.