### PR TITLE
Fix Armenian Stuff 's id.

### DIFF
--- a/Resources/Locale/ru-RU/Imperial/Toughguys/Other.ftl
+++ b/Resources/Locale/ru-RU/Imperial/Toughguys/Other.ftl
@@ -8,7 +8,7 @@ reagent-physical-desc-armenianStuff = шашлычное
 ent-PillThrivevin = Таблетка трайвонина
     .desc = Та самая таблетка!
 
-ent-ArmenianStuffBottle = бутылочка "Армянское счастье" (с)
+ent-ArmenianStuff = бутылочка "Армянское счастье" (с)
     .desc = Секретный рецепт бога Кум'Ара, доработанный Лисьим Богом.
 
 ent-DrinkCafeRaf = Настоящий раф

--- a/Resources/Prototypes/Imperial/TFG/Representative/ShuttleStuff.yml
+++ b/Resources/Prototypes/Imperial/TFG/Representative/ShuttleStuff.yml
@@ -38,11 +38,11 @@
     contents:
       - id: CuttleryBox
       - id: FoodPresentableTinMRECaviar
-      - id: DeliciousRag
+      - id: DeliciousPresentableRag
       - id: DrinkWaterBottleFull
       - id: FoodPresentableTinMRECaviar
         prob: 0.5
-      - id: DeliciousRag
+      - id: DeliciousPresentableRag
         prob: 0.5
       - id: FoodPizzaGolden
         prob: 0.3

--- a/Resources/Prototypes/Imperial/Toughguys/plushie_EasterEgg.yml
+++ b/Resources/Prototypes/Imperial/Toughguys/plushie_EasterEgg.yml
@@ -19,7 +19,7 @@
     price: 100
 
 - type: reagent
-  id: ArmenianStuff
+  id: ArmenianStuffReagent
   name: reagent-name-armenianStuff
   desc: reagent-desc-armenianStuff
   group: Narcotic
@@ -86,7 +86,7 @@
           min: 20
 
 - type: entity
-  id: ArmenianStuffBottle
+  id: ArmenianStuff
   parent: BaseChemistryEmptyBottle
   name: Armenian Stuff
   description: Kum'Ar's secret recipe, adapted by the Fox God.
@@ -102,7 +102,7 @@
       drink:
         maxVol: 60
         reagents:
-          - ReagentId: ArmenianStuff
+          - ReagentId: ArmenianStuffReagent
             Quantity: 60
   - type: SolutionContainerVisuals
     maxFillLevels: 6

--- a/Resources/Prototypes/Imperial/Toughguys/plushie_prototypes.yml
+++ b/Resources/Prototypes/Imperial/Toughguys/plushie_prototypes.yml
@@ -111,7 +111,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: ArmenianStuffBottle
+      - id: ArmenianStuff
 
 - type: entity
   parent: BasePlushieCharacter


### PR DESCRIPTION
Исправлен id для "Армянского Счастья". ArmenianStuff снова ссылается на "entity", а не "reagent".

Исправлены все id в ShuttleBooze.

----

Настроена противотапочковая система для защиты от Миртона. Колени прикрыты дополнительным слоем защиты. 