### PR TITLE
Юрист снова в сервисном отделе

### DIFF
--- a/Resources/Prototypes/Imperial/Juristic department/Juristic deparment.yml
+++ b/Resources/Prototypes/Imperial/Juristic department/Juristic deparment.yml
@@ -5,4 +5,3 @@
   color: "#C71585"
   roles:
   - IAA
-  - Lawyer

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -23,7 +23,7 @@
   - Clown
   - HeadOfPersonnel
   - Janitor
-  ##- Lawyer Imperial department
+  - Lawyer 
   - Librarian
   - Mime
   - Musician


### PR DESCRIPTION
## Об этом ПР'е:
Юрист выписан из юридического департамента и возвращен в сервис.

## Почему/баланс: 
Слишком много разногласий у игроков, вики, всех подряд. Юрист теперь выполняет роль обычного консультанта по юридическим вопросам. 

## Технические детали:
Выписал юриста из `Juristic deratment` в своем прототипе. Убрал комментирование у прошлого юриста.