### PR TITLE
DeathSquad buff

### DIFF
--- a/Resources/Locale/ru-RU/Imperial/ertcall/DeathSquadturret.ftl
+++ b/Resources/Locale/ru-RU/Imperial/ertcall/DeathSquadturret.ftl
@@ -1,0 +1,1 @@
+ent-WeaponTurretDeathSquad = {ent-BaseWeaponTurret}

--- a/Resources/Locale/ru-RU/imperial/ertcall/uplinkCatalog.ftl
+++ b/Resources/Locale/ru-RU/imperial/ertcall/uplinkCatalog.ftl
@@ -214,3 +214,9 @@ ent-ThriveninChemistryBottle = бутылочка трайвонина
 
 ent-ClothingUniformJumpsuitCBURN = комбинезон РХБЗЗ
     .desc = Комбинезон, который используют специальные подразделения для зачистки
+
+ert-uplink-weaponcombat-weaponL6Saw-name = {ent-WeaponLightMachineGunL6}
+ert-uplink-weaponcombat-L6Saw-desc = {ent-WeaponLightMachineGunL6.desc}
+ert-uplink-ammo-MagazineLightRifleBox-name = {ent-MagazineLightRifleBox}
+ert-uplink-utilities-energyshield-name = {ent-EnergyShield}
+ert-uplink-utilities-energyshield-desc = {ent-EnergyShield.desc}

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -204,11 +204,11 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/pulse_rifle.rsi
   - type: Gun
-    fireRate: 1.5
+    fireRate: 1.8 ##Стандартно 1.5. Изменено для баффа дедов //Imperial Space
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser3.ogg
   - type: HitscanBatteryAmmoProvider
-    proto: Pulse
+    proto: PulseDeathSquad ##Стоял стандартный Pulse. Изменен для баффа пушки дедов //Imperial Space
     fireCost: 100
   - type: Battery
     maxCharge: 40000

--- a/Resources/Prototypes/Imperial/ERT_SniperRifle/ert_sniper_projectile.yml
+++ b/Resources/Prototypes/Imperial/ERT_SniperRifle/ert_sniper_projectile.yml
@@ -12,3 +12,21 @@
   impactFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: impact_blue
+
+##DeathSquad start
+- type: hitscan #Новый хитскан для пушек дедов
+  id: PulseDeathSquad
+  damage:
+    types:
+      Heat: 40
+      Structure: 25
+  muzzleFlash:
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
+    state: muzzle_blue
+  travelFlash:
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
+    state: beam_blue
+  impactFlash:
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
+    state: impact_blue
+##DeathSquad end

--- a/Resources/Prototypes/Imperial/ErtCall/DeathSquadturrent.yml
+++ b/Resources/Prototypes/Imperial/ErtCall/DeathSquadturrent.yml
@@ -1,0 +1,8 @@
+- type: entity
+  parent: BaseWeaponTurret
+  id: WeaponTurretDeathSquad
+  suffix: DeathSquad
+  components:
+    - type: NpcFactionMember
+      factions:
+        - DeathSquad

--- a/Resources/Prototypes/Imperial/ErtCall/ErtLoadouts.yml
+++ b/Resources/Prototypes/Imperial/ErtCall/ErtLoadouts.yml
@@ -228,12 +228,12 @@
   id: ERTCallDeadSquadSecurityGearEVA
   equipment:
     jumpsuit: ClothingUniformJumpsuitDeathSquad
-    back: ClothingBackpackDeadSquadSecurityFilled
-    mask: ClothingMaskGasSwat
+    back: ClothingControlModsuitApocryphalSealed ## Замена рюкзака на РИГ
+    mask: ClothingMaskGasDeathSquad
     eyes: ClothingEyesGlassesSecurity
     ears: ClothingHeadsetAltCentCom
     gloves: ClothingHandsGlovesCombat
-    outerClothing: ClothingOuterHardsuitDeathsquad
+## outerClothing: ClothingOuterHardsuitDeathsquad В связи с наличием РИГ'а скафандр убран
     shoes: ClothingShoesBootsMagAdv #DOTO black variant
     id: DeadSquadPDA
     pocket1: ERTUplinkDeadSquad

--- a/Resources/Prototypes/Imperial/ErtCall/ErtPrototypes.yml
+++ b/Resources/Prototypes/Imperial/ErtCall/ErtPrototypes.yml
@@ -189,7 +189,19 @@
       implants:
       - FreedomImplant
       - EmpImplant
-
+    - type: NpcFactionMember
+      factions:
+      - DeathSquad
+      
+- type: npcFaction ##Новая фракция для эскадрона смерти
+  id: DeathSquad
+  hostile:
+  - NanoTrasen
+  - Syndicate
+  - Passive
+  - PetsNT
+  - Zombie
+  - Revolutionary
 #DEAD SQUAD END
 
 

--- a/Resources/Prototypes/Imperial/ErtCall/uplink/ErtCallUplinkCatalog.yml
+++ b/Resources/Prototypes/Imperial/ErtCall/uplink/ErtCallUplinkCatalog.yml
@@ -1154,3 +1154,48 @@
     BlueSpaceCube: 1
   categories:
   - ERTUplinkUtilities
+
+- type: listing
+  id: ErtCallUplinkWeaponL6Saw
+  name: ert-uplink-weaponcombat-weaponL6Saw-name
+  description: ert-uplink-weaponcombat-L6Saw-desc
+  productEntity: WeaponLightMachineGunL6
+  cost:
+    BlueSpaceCube: 15
+  categories:
+  - ERTUplinkWeaponCombat
+  conditions:
+    - !type:StoreWhitelistCondition
+      whitelist:
+        tags:
+          - ErtUplinkDeadSquad
+
+- type: listing
+  id: ErtCallUplinkMagazineLightRifleBox
+  name: ert-uplink-ammo-MagazineLightRifleBox-name
+  description: ert-uplink-ammo-MagazineLightRifleBox-desc
+  productEntity: MagazineLightRifleBox
+  cost:
+    BlueSpaceCube: 4
+  categories:
+  - ERTUplinkAmmoCombat
+  conditions:
+    - !type:StoreWhitelistCondition
+      whitelist:
+        tags:
+          - ErtUplinkDeadSquad
+
+- type: listing
+  id: ErtCallUplinkEnergyShield
+  name: ert-uplink-utilities-energyshield-name
+  description: ert-uplink-utilities-energyshield-desc
+  productEntity: EnergyShield 
+  cost:
+    BlueSpaceCube: 5
+  categories:
+  - ERTUplinkUtilities
+  conditions:
+    - !type:StoreWhitelistCondition
+      whitelist:
+        tags:
+          - ErtUplinkDeadSquad

--- a/Resources/Prototypes/Imperial/Modsuits/Clothing/control.yml
+++ b/Resources/Prototypes/Imperial/Modsuits/Clothing/control.yml
@@ -547,6 +547,11 @@
     autoRot: true
   - type: StaticPrice
     price: 150000
+  - type: Speech # Взрывные РИГ'и
+    speechSounds: Pai
+  - type: ClothingFactionExplosion # Взрывные РИГ'и
+    friendlyFaction: DeathSquad
+    chance: 1
 
 - type: entity
   parent: ClothingControlModsuitBase


### PR DESCRIPTION
## Об этом ПР'е:
Проведен небольшой ребаланс эскадрона смерти и его снаряжения, чтобы им было легче противостоять мерзким врагам корпорации!

## Почему/баланс:
В связи с недавним добавлением RCU эскадрон смерти слегка потерял позиции в вооружении по сравнению с ними. Это как минимум странно, что открытый отряд NT имеет вооружение слегка сильнее, чем засекреченный отряд для зачистки станций от всего живого. Также эскадрон довольно часто начали побеждать, что навевает на мысли о его небольшом баффе.

## Технические детали:
- Эскадрон смерти теперь спавнится в апокрифических РИГ'ах. Убран рюкзак и стартовый скафандр. Все изменения в `ErtLoadouts.yml`
- Немного баффнута винтовка эскадрона смерти. Теперь она имеет скорострельность 1.8 (было 1.5), 40 урона (было 35), 25 структурного урона (не было вообще). Мне кажется, что данная винтовка должна обладать большей разрушительностью, учитывая то, что это главное оружие эскадрона. Все изменения в `battery_guns.yml`, новый проджектайл в нашей папке "ert_sniper_projectile.yml" . Всё измененное закомментировано.
- У дедов появилась собственная фракция, а также проверка ДНК на скафандрах согласно их фракции. Шанс взрыва - 100%. Изменения находятся в `ErtPrototypes.yml`
- В аплинк дед сквада добавлен пулемет L6 Saw и обоймы к нему. Все изменения в `ErtCallUplinkCatalog.yml`
- Добавлены энергощиты в аплинк эскадрона смерти. Все изменения в `ErtCallUplinkCatalog.yml`
- Добавлена турель фракции эскадрона смерти для Гейм Мастеров. Под неё создан отдельный файл `DeathSquadturrent.yml`
- Весь перевод находится в папке Imperial. В формате ftl. 