### PR TITLE
Желтые баллоны вырезаны из снаряжения ОБР

### DIFF
--- a/Resources/Prototypes/Imperial/ErtCall/ErtLoadouts.yml
+++ b/Resources/Prototypes/Imperial/ErtCall/ErtLoadouts.yml
@@ -174,7 +174,7 @@
     id: CBURNPDA
     pocket1: CBURNUplinkLeader
     #pocket2: WeaponLaserGun
-    suitstorage: YellowOxygenTankFilled
+    suitstorage: OxygenTankFilled
     belt: ClothingBeltBandolier
   innerclothingskirt: ClothingUniformJumpsuitColorBrown
   satchel: ClothingBackpackCallERTCBURNFilledLeader
@@ -195,7 +195,7 @@
     id: CBURNPDA
     pocket1: CBURNUplinkSecurity
     #pocket2: WeaponLaserGun
-    suitstorage: YellowOxygenTankFilled
+    suitstorage: OxygenTankFilled
     belt: ClothingBeltBandolier
   innerclothingskirt: ClothingUniformJumpsuitColorBrown
   satchel: ClothingBackpackCallERTCBURNFilled
@@ -216,7 +216,7 @@
     id: PDAMedicalERT
     pocket1: ERTUplinkMedic
     #pocket2: WeaponLaserGun
-    suitstorage: YellowOxygenTankFilled
+    suitstorage: OxygenTankFilled
     belt: ClothingBeltBandolier
   innerclothingskirt: ClothingUniformJumpsuitColorBrown
   satchel: ClothingBackpackCallERTCBURNFilled
@@ -238,7 +238,7 @@
     id: DeadSquadPDA
     pocket1: ERTUplinkDeadSquad
     #pocket2: WeaponLaserGun
-    suitstorage: YellowOxygenTankFilled
+    suitstorage: OxygenTankFilled
     belt: ClothingBeltDeadSquadFilled
 #DEAD SQUAD END
 

--- a/Resources/Prototypes/Imperial/Psychosis/fakeitems.yml
+++ b/Resources/Prototypes/Imperial/Psychosis/fakeitems.yml
@@ -14,7 +14,7 @@
     pocket1: SpiderCharge
     pocket2: PinpointerStation
     belt: EnergyKatana
-    suitstorage: YellowOxygenTankFilled
+    suitstorage: OxygenTankFilled
 
 - type: entity
   parent: WeaponAntiqueLaser


### PR DESCRIPTION
## Об этом ПР'е:
Удалены желтые кислородные баллоны из снаряжения ОБР.

## Почему/баланс:
Жёлтые кислородные баллоны были удалены из игры. В связи с этим отряды сломались.

## Технические детали:
Все кислородные баллоны желтые в снаряжении ОБР заменены на синие. Также fakeitem в психозе заменил. 