### PR TITLE
Изменено наследование рюкзаков эксадрона смерти

### DIFF
--- a/Resources/Prototypes/Imperial/ErtCall/clothing.yml
+++ b/Resources/Prototypes/Imperial/ErtCall/clothing.yml
@@ -199,15 +199,13 @@
 
 #DEAD SQUAD START
 - type: entity
-  parent: ClothingBackpack
+  parent: ClothingBackpackERTSecurity
   id: ClothingBackpackDeadSquadSecurity
   name: Dead squad backpack
   description: You don't have to know whose backpack it is.
   components:
   - type: Sprite
     sprite: Clothing/Back/Backpacks/deadsquad.rsi
-  - type: Storage
-    capacity: 250
 
 - type: entity
   noSpawn: false


### PR DESCRIPTION
## Об этом ПР'е:
Исправлено наследование рюкзака эскадрона смерти. Теперь его инвентарь больше.

## Почему/баланс:
Он наследовался от обычного рюкзака, что делало его инвентарь очень маленьким для рюкзака эскадрона.

## Технические детали:
Изменил наследование на рюкзак ОБР. Теперь инвентарь среднего размера и вполне отвечает запросам эскадрона смерти. 