### PR TITLE
Мелкие фиксы апстрима

### DIFF
--- a/Resources/Prototypes/Imperial/Sona/PDA/PDA.yml
+++ b/Resources/Prototypes/Imperial/Sona/PDA/PDA.yml
@@ -5,18 +5,31 @@
   suffix: S-o.N.A
   description: A beautiful and advanced PDA of S-o.N.A. AI Dynamics Corporation.
   components:
-    - type: Item
-      size: Small
-    - type: Pda
-      id: SonaIDCard
-      state: pda-sona
-    - type: Icon
-      state: pda-sona
-    - type: PdaBorderColor
-      borderColor: "#f2f2f2"
-      accentHColor: "#00f1f5"
-      accentVColor: "#00f1f5"
-    - type: HealthAnalyzer
-      scanDelay: 0
-      scanningEndSound:
-        path: "/Audio/Items/Medical/healthscanner.ogg"
+  - type: Sprite
+    sprite: Imperial/customPDA.rsi
+    layers:
+    - map: [ "enum.PdaVisualLayers.Base" ]
+    - state: "light_overlay"
+      map: [ "enum.PdaVisualLayers.Flashlight" ]
+      shader: "unshaded"
+      visible: false
+    - state: "id_overlay"
+      map: [ "enum.PdaVisualLayers.IdLight" ]
+      shader: "unshaded"
+      visible: false
+  - type: Item
+    size: Small
+  - type: Pda
+    id: SonaIDCard
+    state: pda-sona
+  - type: Icon
+    sprite: Imperial/customPDA.rsi
+    state: pda-sona
+  - type: PdaBorderColor
+    borderColor: "#f2f2f2"
+    accentHColor: "#00f1f5"
+    accentVColor: "#00f1f5"
+  - type: HealthAnalyzer
+    scanDelay: 0
+    scanningEndSound:
+      path: "/Audio/Items/Medical/healthscanner.ogg"

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -102,7 +102,7 @@
 
 - type: stealTargetGroup
   id: HeadBedsheet
-  name: одеяло (любые)
+  name: одеяло (глав)
   sprite:
     sprite: Objects/Misc/bedsheets.rsi
     state: sheetNT

--- a/Resources/Textures/Imperial/customPDA.rsi/meta.json
+++ b/Resources/Textures/Imperial/customPDA.rsi/meta.json
@@ -35,15 +35,7 @@
             "name": "pda-made"
         },
         {
-            "name": "pda-sona",
-            "delays": [
-                [
-                    0.8,
-                    0.8,
-                    0.8,
-                    0.8
-                ]
-            ]
+            "name": "pda-sona"
         },
         {
             "name": "pda-elysiumFederation"


### PR DESCRIPTION
## Об этом ПР'е: 
Слетел спрайт КПК Sona. Исправил его. Изменил локализацию в тексте задания вора на кражу одеял.

## Почему/баланс:
В случае с КПК - ERROR и невозможность проведения ивентов. В случае с целью вора - вводила в заблуждение игроков. Там нужны сугубо одеяла глав.

## Технические детали:
Добавлен компонент спрайта к КПК Sona. Слово (любое) в задании вора на кражу изменено на (глав)