### PR TITLE
Фикс рюкзака БМ'а

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
@@ -62,6 +62,7 @@
   - type: StorageFill
     contents:
       - id: Flash
+      - id: BoxSurvivalBrigmedic
 
 - type: entity
   noSpawn: true


### PR DESCRIPTION
## Об этом ПР'е:
Добавлен аварийный набор во вторую сумку бригмедика.

## Почему/баланс:
При выборе другой сумки, кроме стандартного рюкзака, появляется сумка без аварийного набора.


## Технические детали:
Добавлен аварийный набор бригмедика в сумку бригмедика. 