### PR TITLE
Фикс тревожности

### DIFF
--- a/Content.Server/Speech/EntitySystems/StutteringSystem.cs
+++ b/Content.Server/Speech/EntitySystems/StutteringSystem.cs
@@ -13,7 +13,7 @@ namespace Content.Server.Speech.EntitySystems
         [Dependency] private readonly IRobustRandom _random = default!;
 
         // Regex of characters to stutter.
-        private static readonly Regex Stutter = new(@"[b-df-hj-np-tv-wxyz]",
+        private static readonly Regex Stutter = new(@"[b-df-hj-np-tv-wxyz-б-вд-к-лмн-прст]", // Ru-localization
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public override void Initialize()


### PR DESCRIPTION
## Об этом ПР'е:
Добавлен русский язык в регистр заикания

## Почему/баланс:
Из-за отсутствия русского регистра не работало заикание в тревожности и в принципе

## Технические детали:
Добавил новый регистр в StutteringSystem. Комментарий оставлен. 