### PR TITLE
Фикс вещмешка бригмедика

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/duffelbag.yml
@@ -48,6 +48,7 @@
   - type: StorageFill
     contents:
       - id: Flash
+      - id: BoxSurvivalBrigmedic
 
 - type: entity
   noSpawn: true


### PR DESCRIPTION
## Об этом ПР'е:
Фикс сумки бригмедика. Теперь в ней есть аварийный набор

## Почему/баланс:
В вещмешке бригмедика не было аварийного набора. 

## Технические детали:
В прототип заполненного вещмешка бригмедика добавлен аварийный набор. Сторонние файлы не редактировались. 