### PR TITLE
Небольшой фикс стен шаттлов

### DIFF
--- a/Resources/Textures/Structures/Walls/shuttle.rsi/meta.json
+++ b/Resources/Textures/Structures/Walls/shuttle.rsi/meta.json
@@ -41,6 +41,24 @@
         {
             "name": "state7",
             "directions": 4
+        },
+        {
+            "name": "shuttle_construct-0"
+        },
+        {
+            "name": "shuttle_construct-1"
+        },
+        {
+            "name": "shuttle_construct-2"
+        },
+        {
+            "name": "shuttle_construct-3"
+        },
+        {
+            "name": "shuttle_construct-4"
+        },
+        {
+            "name": "shuttle_construct-5"
         }
     ]
 }


### PR DESCRIPTION
## Об этом ПР'е:
Фикс стен шаттлов, чтобы они не выдавали ERROR при разборке.

## Почему/баланс:
Потому что возникает ERROR.

## Технические детали:
Внес новые стейты в мета файл.