### PR TITLE
damageType fix

### DIFF
--- a/Resources/Prototypes/Damage/types.yml
+++ b/Resources/Prototypes/Damage/types.yml
@@ -18,17 +18,17 @@
   id: Blunt
   armorCoefficientPrice: 2
   armorFlatPrice: 10
-  
+
 - type: damageType
   id: Cellular
   armorCoefficientPrice: 5
   armorFlatPrice: 30
-  
+
 - type: damageType
   id: Caustic
   armorCoefficientPrice: 5
   armorFlatPrice: 30
-  
+
 - type: damageType
   id: Cold
   armorCoefficientPrice: 2.5
@@ -71,3 +71,9 @@
   id: Structural
   armorCoefficientPrice: 1
   armorFlatPrice: 1
+
+#Imperial Space
+- type: damageType
+  id: Stamina
+  armorCoefficientPrice: 0
+  armorFlatPrice: 0


### PR DESCRIPTION
Небольшой фикс damageType прототипа. Должен помочь избежать ошибок и вернуться пиратам в игру.
