### PR TITLE
Повышает цену Тактического рига до 70 тк

### DIFF
--- a/Resources/Prototypes/Imperial/Modsuits/misc.yml
+++ b/Resources/Prototypes/Imperial/Modsuits/misc.yml
@@ -49,7 +49,7 @@
   description: uplink-modsuitoperativecmd-desc
   productEntity: ClothingControlModsuitPMCSealed
   cost:
-    Telecrystal: 50
+    Telecrystal: 70
   categories:
     - UplinkArmor
   conditions:


### PR DESCRIPTION
Затраты на одного бойца ядерных оперативников, на котором заточена основная боевая мощь отряда оказалась слишком маленькой, что-бы компенсировать что-то либо ещё в основном закупе
Повышение цены для военного РИГа предназначена для того, что-бы команда  оперативников компенсировала бойца на котором сосредоточена основная боевая мощь отряда чем-то другим в закупе, расходниками, оружием и т.д
  Текст писала нейронка
