### PR TITLE
Временно аннигилирует тактический риг из аплинка

### DIFF
--- a/Resources/Prototypes/Imperial/Modsuits/misc.yml
+++ b/Resources/Prototypes/Imperial/Modsuits/misc.yml
@@ -43,20 +43,20 @@
       tags:
       - NukeOpsUplink
 
-- type: listing
-  id: ModsuitNukeOperativeCMDSealed
-  name: uplink-modsuitoperativecmd-name
-  description: uplink-modsuitoperativecmd-desc
-  productEntity: ClothingControlModsuitPMCSealed
-  cost:
-    Telecrystal: 70
-  categories:
-    - UplinkArmor
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - NukeOpsUplink
+# - type: listing
+#   id: ModsuitNukeOperativeCMDSealed
+#   name: uplink-modsuitoperativecmd-name
+#   description: uplink-modsuitoperativecmd-desc
+#   productEntity: ClothingControlModsuitPMCSealed
+#   cost:
+#     Telecrystal: 70
+#   categories:
+#     - UplinkArmor
+#   conditions:
+#   - !type:StoreWhitelistCondition
+#     whitelist:
+#       tags:
+#       - NukeOpsUplink
 
 - type: entity
   id: RandomModsuitCrate


### PR DESCRIPTION
Тактический риг не делает раунд весёлым, а меры, принятые для его дебаффа в https://github.com/imperial-space/space-station14-public/pull/197 не удались. Ничего не изменилось. Можно, конечно, продолжать добавлять по 5 тк каждый ПР, но проблема с тактическим ригом фундаментальна -- ему нужен реворк, а в подобном виде он не должен быть в игре. Через некоторое время отправлю ПР-баланс Тактического рига или вовсе его удалю.