### PR TITLE
Баланс цены энерго-арбалетика

### DIFF
--- a/Resources/Prototypes/Imperial/MiniCrossbow/uplink_catalog.yml
+++ b/Resources/Prototypes/Imperial/MiniCrossbow/uplink_catalog.yml
@@ -5,7 +5,7 @@
   description: uplink-energy-crossbow-desc
   productEntity: energy-crossbow
   cost:
-    Telecrystal: 11
+    Telecrystal: 8
   categories:
   - UplinkWeapons
   conditions:


### PR DESCRIPTION
## О PR-e
Изменяет стоимость энерго-арбалетика с 11 до 8 ТК

## Почему / Баланс
Энерго-арбалетик в настоящее время имеет ограниченные возможности использования в качестве самостоятельного оружия из-за его высокой стоимости, однако снижение цены может сделать его более доступным и популярным среди пользователей. Это также откроет новые возможности для создания уникальных комбинаций и тактических применений. В настоящее время стоимость энерго-арбалетика в 11 ТК не соответствует его функциональным возможностям и потенциалу, и уменьшение цены может сделать его более привлекательным для широкого круга потенциальных пользователей.