### PR TITLE
Фикс админ размера админ окон, чтобы они нормально открывались

### DIFF
--- a/Content.Client/Administration/UI/AdminMenuWindow.xaml.cs
+++ b/Content.Client/Administration/UI/AdminMenuWindow.xaml.cs
@@ -12,7 +12,7 @@ namespace Content.Client.Administration.UI
 
         public AdminMenuWindow()
         {
-            MinSize = new Vector2(650, 250);
+            MinSize = new Vector2(700, 250);
             Title = Loc.GetString("admin-menu-title");
             RobustXamlLoader.Load(this);
             MasterTabContainer.SetTabTitle(0, Loc.GetString("admin-menu-admin-tab"));

--- a/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml
@@ -1,6 +1,6 @@
 ﻿<DefaultWindow xmlns="https://spacestation14.io"
             xmlns:cc="clr-namespace:Content.Client.Administration.UI.Bwoink"
-            SetSize="900 500"
+            SetSize="1000 500"
             HeaderClass="windowHeaderAlert"
             TitleClass="windowTitleAlert"
             Title="{Loc 'bwoink-user-title'}" >


### PR DESCRIPTION
## Об этом ПР'е:
Изменены размеры окон админов, чтобы при открытии слова не накладывались друг на друга

## Почему/баланс:
Неудобно для администрации.

## Технические детали:
- Изменена ширина у окна администрации с `650` до `700`
- Изменена ширина у окна ахелпа с `900` до `1000`