### PR TITLE
уголь теперь не используется для создания материалов

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/Recipes/Lathes/sheet.yml
@@ -12,7 +12,7 @@
   completetime: 2
   materials:
     RawIron: 3000
-    Coal: 1000
+    ##Coal: 1000 Imperial edit Imperial edit
 
 - type: latheRecipe
   id: SheetGlass1
@@ -45,7 +45,7 @@
   materials:
     RawQuartz: 3000
     RawIron: 1500
-    Coal: 500
+    #Coal: 500 Imperial Edit
 
 - type: latheRecipe
   id: SheetPGlass30
@@ -63,7 +63,7 @@
     RawQuartz: 3000
     RawPlasma: 3000
     RawIron: 1500
-    Coal: 500
+    #Coal: 500 Imperial Edit
 
 - type: latheRecipe
   id: SheetPlasma30
@@ -79,7 +79,7 @@
   materials:
     RawPlasma: 3000
     RawIron: 6000 #Twice as durable as steel, Twice the material cost
-    Coal: 1000
+    #Coal: 1000 Imperial edit
 
 - type: latheRecipe
   id: SheetUranium30
@@ -104,7 +104,7 @@
     RawUranium: 3000
     RawQuartz: 3000
     RawIron: 1500
-    Coal: 500
+    #Coal: 500 Imperial edit
 
 - type: latheRecipe
   id: IngotGold30


### PR DESCRIPTION
уголь теперь не используется для создания материалов
Уголь в игре "Space Station" представляет собой лишнее усложнение, которое ухудшает игровой процесс. Для добычи обычной стали теперь необходимо добывать целых две руды на астероидах, где сталь и уголь практически не встречаются одновременно. Эти ресурсы необходимы для всех отделов на станции, особенно для Рнд. Введение угля как обязательного материала для создания стали (и других ресурсов) приводит к нехватке ресурсов на станции на протяжении всего раунда, убивая динамику и качество игры у всех членов экипажа. Если еще добавить утилизаторов, которые тупо играют в свою ПВЕшку, вообще не вспоминая про станцию, можно заплакать.