### PR TITLE
Убран заказ в карго

### DIFF
--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -461,16 +461,16 @@
       components:
       - AnomalyCore
 
-- type: cargoBounty
-  id: BountyBorgModule
-  reward: 3500
-  description: bounty-description-borg-module
-  entries:
-  - name: bounty-item-borg-module
-    amount: 3
-    whitelist:
-      components:
-      - BorgModule
+# - type: cargoBounty Так как у нас нет модулей киборгов, то будет вырезано. Imperial Space
+#   id: BountyBorgModule
+#   reward: 3500
+#   description: bounty-description-borg-module
+#   entries:
+#   - name: bounty-item-borg-module
+#     amount: 3
+#     whitelist:
+#       components:
+#       - BorgModule
 
 - type: cargoBounty
   id: BountyArtifactFragment


### PR DESCRIPTION
## Об этом ПР'е:
Удален заказ на платы киборгов в карго.

## Почему/баланс:
Это визардовские платы. В нашем случае они не нужны и их нет банально на станции.

## Технические детали:
Закомментирован `BountyBorgModule` с припиской Империала. Больше данный заказ появляться не должен. 