### PR TITLE
Стамина урон у дсворда

### DIFF
--- a/Resources/Prototypes/Imperial/DualToySword/dualtoy.yml
+++ b/Resources/Prototypes/Imperial/DualToySword/dualtoy.yml
@@ -66,3 +66,5 @@
     node: DualToySword
   - type: Reflect
     reflectProb: 0
+  - type: StaminaDamageOnHit
+    damage: 2


### PR DESCRIPTION
## Об этом ПР'е:
Игрушечному лазерному мечу добавлен маленький урон на стамину.

## Почему/баланс:
У одинарного меча есть стамина урон. У двойного нет. Не порядок! Сделал минимальный стамина урон, чтобы это не превратилось в очередную стан мету. По итогу человеку без стамина резиста нужно нанести 50 ударов (с учетом скорости дсворда вполне приемлемо). 

## Технические детали:
Добавлен компонент `StaminaDamageOnHit` к игрушечному лазерному мечу. При желании могу снизить и до 1 стамина дамага, но тогда он будет намного хуже одинарного)