### PR TITLE
Исправление фракции дедов

### DIFF
--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -7,6 +7,7 @@
     - PetsNT
     - Zombie
     - Revolutionary
+    - DeathSquad # Imperial Space faction
 
 - type: npcFaction
   id: NanoTrasen
@@ -42,6 +43,7 @@
   - PetsNT
   - Zombie
   - Revolutionary
+  - DeathSquad # Imperial Space faction
 
 - type: npcFaction
   id: SimpleNeutral
@@ -54,6 +56,7 @@
   - Xeno
   - PetsNT
   - Zombie
+  - DeathSquad # Imperial Space faction
 
 - type: npcFaction
   id: Xeno
@@ -64,6 +67,7 @@
   - PetsNT
   - Zombie
   - Revolutionary
+  - DeathSquad # Imperial Space faction
 
 - type: npcFaction
   id: Zombie
@@ -75,6 +79,7 @@
   - Passive
   - PetsNT
   - Revolutionary
+  - DeathSquad # Imperial Space faction
 
 - type: npcFaction
   id: Revolutionary
@@ -83,3 +88,4 @@
   - Zombie
   - SimpleHostile
   - Dragon
+  - DeathSquad # Imperial Space faction


### PR DESCRIPTION
## Об этом ПР'е: 
Исправлена фракция дед сквада. Теперь её считают за врага все, кроме НаноТрайзен. 

## Почему/баланс:
Потому что все враждебные мобы не атаковали эскадрон.

## Технические детали:
Фракция эскадрона смерти занесена во враги всех фракций, изначально враждебных к НТ. Также добавил комментарии. 