### PR TITLE
Фикс ошибки из-за потерянного слоя

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
@@ -57,6 +57,11 @@
   - type: Sprite
     layers:
     - state: pinpointer-syndicate
+      map: ["enum.PinpointerLayers.Base"]
+    - state: pinonnull
+      map: ["enum.PinpointerLayers.Screen"]
+      shader: unshaded
+      visible: false
   - type: Icon
     state: pinpointer-syndicate
   - type: Pinpointer
@@ -72,6 +77,11 @@
   - type: Sprite
     layers:
     - state: pinpointer-way
+      map: ["enum.PinpointerLayers.Base"]
+    - state: pinonnull
+      map: ["enum.PinpointerLayers.Screen"]
+      shader: unshaded
+      visible: false
   - type: Icon
     state: pinpointer-way
   - type: Pinpointer
@@ -88,6 +98,11 @@
   - type: Sprite
     layers:
     - state: pinpointer-station
+      map: ["enum.PinpointerLayers.Base"]
+    - state: pinonnull
+      map: ["enum.PinpointerLayers.Screen"]
+      shader: unshaded
+      visible: false
   - type: Icon
     state: pinpointer-station
   - type: Pinpointer


### PR DESCRIPTION
## Об этом ПР'е:
Исправлены неправильно выставленные слои в прототипах поисковых навигаторов.

## Почему/баланс:
При включении некоторых поисковых навигаторов в консоль выдавалось множество ошибок

## Технические детали:
Добавил недостающие слои в прототип пинпоинтеров (по сути визарды в будущем сделают также, а конкретнее - 1 мая)
https://github.com/space-wizards/space-station-14/pull/27582
Конфликтов вызвать не должно. Система пинпоинтеров за это время не менялась, а данный твик лишь добавляет слой, убирая достающие ошибки. 
