### PR TITLE
Багфикс фейковых ядеров в манифесте

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -204,7 +204,21 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
             }
         }
 
-        Action<EntityUid, MindContainerComponent?> displayNukeopsToManifest = (uid, container) => {
+        // ev.AddLine(Loc.GetString("nukeops-list-start"));
+
+        // var nukiesQuery = EntityQueryEnumerator<NukeopsRoleComponent, MindContainerComponent>();
+        // while (nukiesQuery.MoveNext(out var nukeopsUid, out _, out var mindContainer))
+        // {
+        //     if (!_mind.TryGetMind(nukeopsUid, out _, out var mind, mindContainer))
+        //         continue;
+
+        //     ev.AddLine(mind.Session != null
+        //         ? Loc.GetString("nukeops-list-name-user", ("name", Name(nukeopsUid)), ("user", mind.Session.Name))
+        //         : Loc.GetString("nukeops-list-name", ("name", Name(nukeopsUid))));
+        // }
+
+        Action<EntityUid, MindContainerComponent?> displayNukeopsToManifest = (uid, container) =>
+        { // Imperial Space Start
             if (!_mind.TryGetMind(uid, out _, out var mind, container)) return;
 
             ev.AddLine(mind.Session != null
@@ -223,7 +237,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         }
 
         do displayNukeopsToManifest(nukeopsUid, mindContainer);
-        while (nukiesQuery.MoveNext(out nukeopsUid, out _, out mindContainer));
+        while (nukiesQuery.MoveNext(out nukeopsUid, out _, out mindContainer)); // Imperial Space End
     }
 
     private void OnNukeExploded(NukeExplodedEvent ev)

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -217,8 +217,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         //         : Loc.GetString("nukeops-list-name", ("name", Name(nukeopsUid))));
         // }
 
-        Action<EntityUid, MindContainerComponent?> displayNukeopsToManifest = (uid, container) =>
-        { // Imperial Space Start
+        Action<EntityUid, MindContainerComponent?> displayNukeopsToManifest = (uid, container) => // Imperial Space Start
+        {
             if (!_mind.TryGetMind(uid, out _, out var mind, container)) return;
 
             ev.AddLine(mind.Session != null

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -217,7 +217,9 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         //         : Loc.GetString("nukeops-list-name", ("name", Name(nukeopsUid))));
         // }
 
-        Action<EntityUid, MindContainerComponent?> displayNukeopsToManifest = (uid, container) => // Imperial Space Start
+        // Imperial Space nukeops-manifest-fix Start
+
+        Action<EntityUid, MindContainerComponent?> displayNukeopsToManifest = (uid, container) =>
         {
             if (!_mind.TryGetMind(uid, out _, out var mind, container)) return;
 
@@ -237,7 +239,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         }
 
         do displayNukeopsToManifest(nukeopsUid, mindContainer);
-        while (nukiesQuery.MoveNext(out nukeopsUid, out _, out mindContainer)); // Imperial Space End
+        while (nukiesQuery.MoveNext(out nukeopsUid, out _, out mindContainer));
+        // Imperial Space nukeops-manifest-fix End
     }
 
     private void OnNukeExploded(NukeExplodedEvent ev)


### PR DESCRIPTION

## О ПР`е
Исправление бага с фейковыми ядерными оперативниками в манифесте

## Причины бага
Видимо, что при окончании раунда вызываются методы OnRoundEndText всех режимов, которые отвечают за записыванние в манифест информации о них. OnRoundEndText в системе нюки не имел заглушку, если самого режима не было, поэтому при любых обстоятельствах появлялось сообщение о ядерах.
