### PR TITLE
Фикс бригмедика

### DIFF
--- a/Resources/Prototypes/Imperial/Brigmedic/brigmedic.yml
+++ b/Resources/Prototypes/Imperial/Brigmedic/brigmedic.yml
@@ -17,12 +17,20 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingMaskBreathMedicalSecurity
+      - id: ClothingMaskRebreatherBrigmedic
       - id: EmergencyOxygenTankFilled
+      - id: SpaceMedipen #Imperial spaceMedipen add to surv boxes
       - id: EmergencyMedipen
+      - id: Flare
+      - id: FoodSnackNutribrick
+      - id: DrinkWaterBottleFull
       - id: EmergencyMedipen
-      - id: FoodTinMRE
   - type: Sprite
     layers:
       - state: internals
       - state: emergencytank
+  #Imperial emergency box size
+  - type: Storage
+    maxItemSize: Small
+    grid:
+    - 0,0,3,2

--- a/Resources/Prototypes/Imperial/Brigmedic/brigmedicIDCard.yml
+++ b/Resources/Prototypes/Imperial/Brigmedic/brigmedicIDCard.yml
@@ -7,3 +7,5 @@
     layers:
     - state: default
     - state: idbrigmedic
+  - type: PresetIdCard
+    job: Brigmedic

--- a/Resources/Prototypes/Imperial/Brigmedic/brigmedicgearpreset.yml
+++ b/Resources/Prototypes/Imperial/Brigmedic/brigmedicgearpreset.yml
@@ -37,7 +37,6 @@
     head: ClothingHeadHatBeretBrigmedic
     id: BrigmedicPDA
     ears: ClothingHeadsetBrigmedic
-    mask: ClothingMaskRebreatherBrigmedic
     belt: ClothingBeltMilitaryWebbingBrigmedFilled
   innerclothingskirt: ClothingUniformJumpskirtBrigmedicNew
   satchel: ClothingBackpackSatchelBrigmedicFilled
@@ -60,3 +59,6 @@
   innerClothingSkirt: ClothingUniformJumpskirtBrigmedic
   satchel: ClothingBackpackSatchelBrigmedicFilled
   duffelbag: ClothingBackpackDuffelBrigmedicFilled
+
+- type: playTimeTracker
+  id: JobBrigmedic


### PR DESCRIPTION
## Об этом ПР'е:
- Исправлен аварийный набор бригмедика. Теперь у него нормальный размер. Заменен ребризер на наш кастомный. Наполнение отредактировано.
- Ребризер по стандарту снят с лица бригмедика. Теперь пусть достает из набора
- Исправлено отображение иконки на консоли криминала на паблике
- Добавлен трекер в паблик

## Почему/баланс:
В результате переноса в отдельную роль пострадали некоторые предметы из-за разногласий между пабликом и привейтом

## Технические детали:
Все исправления в соответствующих папках бригмедика. За них не заходил. Отредактированы brigmedic.yml со снаряжением бригмедика, добавлен `- type: PresetIdCard` в карту бригмедика для корректного отображения роли на паблике. В пресет добавлен трекер и убран ребризер по стандарту