### PR TITLE
Solution

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1257,7 +1257,7 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
   cost:
-    Telecrystal: 12 #Imperial Balance
+    Telecrystal: 14 #Imperial Balance
   categories:
   - UplinkWearables
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1257,7 +1257,7 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
   cost:
-    Telecrystal: 10
+    Telecrystal: 12 #Imperial Balance
   categories:
   - UplinkWearables
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -527,11 +527,11 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.6
+        Blunt: 0.5 #Imperial Balance
+        Slash: 0.5 #Imperial Balance
+        Piercing: 0.4 #Imperial Balance
         Heat: 0.2
-        Radiation: 0.01
+        Radiation: 0.2 #Imperial Balance
         Caustic: 0.5
         Stamina: 0.5 ## Stamina resistance
   - type: Item

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -527,18 +527,18 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.5 #Imperial Balance
-        Slash: 0.5 #Imperial Balance
+        Blunt: 0.6 #Imperial Balance
+        Slash: 0.6 #Imperial Balance
         Piercing: 0.4 #Imperial Balance
-        Heat: 0.2
-        Radiation: 0.2 #Imperial Balance
+        Heat: 0.3 #Imperial Balance
+        Radiation: 0.3 #Imperial Balance
         Caustic: 0.5
         Stamina: 0.5 ## Stamina resistance
   - type: Item
     size: Huge
   - type: ClothingSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
+    walkModifier: 0.9 #Imperial Balance
+    sprintModifier: 0.9 #Imperial Balance
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite


### PR DESCRIPTION
## О PR-е
Изменяет статы скафандру медика
40% Piercing -> 60%
40% Blunt -> 50%
40% Slash -> 50%
99% Radiation -> 80%

## Почему / Баланс
Визарды как всегда насрали и сделали убогие статы скафандру медика, думаю вам должно быть очевидно почему их стоит изменить на почти прежние.
А если не очевидно, то объясняю. 
Давать 99% резистов от радиации глупая идея, такое должны быть только у старшего инженера или кого-то такого. Даже у костюма против радиации нет такого гигантского резиста.
А ставить статы которые меньше СТАТОВ ОБЫЧНОГО ЯДЕРНОГО ОПЕРАТИВНИКА это совсем глупая идея. Это же должен быть улучшенный скафандр нюкера, а не наоборот.