### PR TITLE
Удален ванильных борг ЯО из аплинка

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -899,21 +899,21 @@
         tags:
           - NukeOpsUplink
 
-- type: listing
-  id: UplinkReinforcementRadioSyndicateCyborgAssault
-  name:  uplink-reinforcement-radio-cyborg-assault-name
-  description: uplink-reinforcement-radio-cyborg-assault-desc
-  productEntity: ReinforcementRadioSyndicateCyborgAssault
-  icon: { sprite: Mobs/Silicon/chassis.rsi, state: synd_sec }
-  cost:
-    Telecrystal: 65
-  categories:
-    - UplinkAllies
-  conditions:
-    - !type:StoreWhitelistCondition
-      whitelist:
-        tags:
-          - NukeOpsUplink
+# - type: listing Удалено, так как ванильные борги визардов у нас не используются //Imperial Space
+#   id: UplinkReinforcementRadioSyndicateCyborgAssault
+#   name:  uplink-reinforcement-radio-cyborg-assault-name
+#   description: uplink-reinforcement-radio-cyborg-assault-desc
+#   productEntity: ReinforcementRadioSyndicateCyborgAssault
+#   icon: { sprite: Mobs/Silicon/chassis.rsi, state: synd_sec }
+#   cost:
+#     Telecrystal: 65
+#   categories:
+#     - UplinkAllies
+#   conditions:
+#     - !type:StoreWhitelistCondition
+#       whitelist:
+#         tags:
+#           - NukeOpsUplink
 
 - type: listing
   id: UplinkReinforcementRadioSyndicateMonkey


### PR DESCRIPTION
## Об этом ПР'е:
Удален ванильный штурмовой борг ЯО.

## Почему/баланс:
Есть наша версия киборга, к тому же эта отличается по балансу и по техническим характеристикам

## Технические детали:
Строчка с возможностью покупки борга в аплинке закомментирована с припиской, что сделано нами. Самого борга не трогал, может для ивентов захотят использовать. 