### PR TITLE
Перенос АКМС

### DIFF
--- a/Resources/Prototypes/Imperial/BundleAKMS/uplink_catalog.yml
+++ b/Resources/Prototypes/Imperial/BundleAKMS/uplink_catalog.yml
@@ -7,7 +7,7 @@
   cost:
     Telecrystal: 22
   categories:
-  - UplinkBundles
+  - UplinkWeaponry
   conditions:
    - !type:StoreWhitelistCondition
      whitelist:


### PR DESCRIPTION
## Об этом ПР'е:
АКМС перенесен из раздела "наборы" в раздел "оружие" в аплинке ко всем остальным наборам.

## Почему/баланс:
Раздел "наборы" был удален разработчиками игры, из-за чего набор просто пропал.

## Технические детали: 
Заменена строка `UplinkBundles` на `UplinkWeaponry`. Теперь АКМС снова появляется в аплинке. 