### PR TITLE
Фикс отображения правил у гост ролей

### DIFF
--- a/Content.Server/Ghost/Roles/Components/GhostRoleComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostRoleComponent.cs
@@ -12,7 +12,7 @@ namespace Content.Server.Ghost.Roles.Components
 
         [DataField("description")] private string _roleDescription = "Unknown";
 
-        [DataField("rules")] private string _roleRules = "";
+        [DataField("rules")] private string _roleRules = "ghost-role-component-default-rules";
 
         [DataField("requirements")]
         public HashSet<JobRequirement>? Requirements;


### PR DESCRIPTION
## Об этом ПР'е:
Гост ролям возвращены описания по умолчанию

## Почему/баланс:
После всех обнов почему-то пропала строчка о дефолтных правилах гост ролей

## Технические детали:
Добавлено ghost-role-component-default-rules в значение правил по умолчанию. 