### PR TITLE
Фикс наполнения ящика бригмедика

### DIFF
--- a/Resources/Prototypes/Imperial/Brigmedic/brigmediclocker.yml
+++ b/Resources/Prototypes/Imperial/Brigmedic/brigmediclocker.yml
@@ -27,8 +27,12 @@
       - id: BoxSterileMask
       - id: ClothingHeadHatBeretBrigmedic
       - id: ClothingOuterCoatAMG
-      - id: ClothingUniformJumpsuitBrigmedic
-      - id: ClothingUniformJumpskirtBrigmedic
+      - id: ClothingHeadHelmetBrigmedic #Imperia start
+      - id: ClothingUniformJumpsuitBrigmedicNew
+      - id: ControlModsuitRescue
+      - id: ClothingUniformJumpskirtBrigmedicNew #Imperia end
+      # - id: ClothingUniformJumpsuitBrigmedic //Удалено для внесения наших вещей Imperial
+      # - id: ClothingUniformJumpskirtBrigmedic //Удалено для внесения наших вещей Imperial
       - id: ClothingUniformJumpskirtOfLife
         prob: 0.1
       - id: MedkitFilled


### PR DESCRIPTION
## Об этом ПР'е:
Изменено наполнение ящика бригмедика. Убраны ванильные визардовские предметы. Заменены на наши.

## Почему/баланс:
Потому что отсутствовали наши вещи+ванильные были со старыми текстурами

## Технические детали:
Добавлены новые предметы в прототип ящика бригмедика. Ванильная одежда закомментирована. В сторонние файлы изменения не вносились. 