### PR TITLE
Багфикс ядеров в манифесте. Опять.

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -47,6 +47,10 @@ using Robust.Shared.Random;
 using Robust.Shared.Utility;
 using System.Linq;
 
+// Imperial Space nukeops-fix Imports Start
+using Content.Shared.Mind;
+// Imperial Space nukeops-fix Imports End
+
 namespace Content.Server.GameTicking.Rules;
 
 public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
@@ -192,10 +196,14 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
     private void OnRoundEndText(RoundEndTextAppendEvent ev)
     {
         var ruleQuery = QueryActiveRules();
+        bool nukeInRound = false; // Imperial Space nukeops-fix
+
         while (ruleQuery.MoveNext(out _, out _, out var nukeops, out _))
         {
             var winText = Loc.GetString($"nukeops-{nukeops.WinType.ToString().ToLower()}");
             ev.AddLine(winText);
+
+            nukeInRound = true; // Imperial Space nukeops-fix
 
             foreach (var cond in nukeops.WinConditions)
             {
@@ -204,7 +212,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
             }
         }
 
-        // ev.AddLine(Loc.GetString("nukeops-list-start"));
+        if (nukeInRound) ev.AddLine(Loc.GetString("nukeops-list-start")); // Imperial Space nukeops-fix
 
         // var nukiesQuery = EntityQueryEnumerator<NukeopsRoleComponent, MindContainerComponent>();
         // while (nukiesQuery.MoveNext(out var nukeopsUid, out _, out var mindContainer))
@@ -217,30 +225,18 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         //         : Loc.GetString("nukeops-list-name", ("name", Name(nukeopsUid))));
         // }
 
-        // Imperial Space nukeops-manifest-fix Start
-
-        Action<EntityUid, MindContainerComponent?> displayNukeopsToManifest = (uid, container) =>
+        // Imperial Space nukeops-fix Start
+        var nukiesQuery = EntityQueryEnumerator<NukeopsRoleComponent, MindComponent>();
+        while (nukiesQuery.MoveNext(out var nukeopsUid, out _, out var mind))
         {
-            if (!_mind.TryGetMind(uid, out _, out var mind, container)) return;
+            if (mind == null) continue;
+            var nukeopName = Name(nukeopsUid);
 
             ev.AddLine(mind.Session != null
-                ? Loc.GetString("nukeops-list-name-user", ("name", Name(uid)), ("user", mind.Session.Name))
-                : Loc.GetString("nukeops-list-name", ("name", Name(uid))));
-        };
-
-        var nukiesQuery = EntityQueryEnumerator<NukeopsRoleComponent, MindContainerComponent>();
-        EntityUid nukeopsUid;
-        MindContainerComponent? mindContainer;
-
-        if (nukiesQuery.MoveNext(out nukeopsUid, out _, out mindContainer))
-        {
-            ev.AddLine(Loc.GetString("nukeops-list-start"));
-            displayNukeopsToManifest(nukeopsUid, mindContainer);
+                ? Loc.GetString("nukeops-list-name-user", ("name", nukeopName[6..^1]), ("user", mind.Session.Name))
+                : Loc.GetString("nukeops-list-name", ("name", nukeopName[6..^1])));
         }
-
-        do displayNukeopsToManifest(nukeopsUid, mindContainer);
-        while (nukiesQuery.MoveNext(out nukeopsUid, out _, out mindContainer));
-        // Imperial Space nukeops-manifest-fix End
+        // Imperial Space nukeops-fix End
     }
 
     private void OnNukeExploded(NukeExplodedEvent ev)
@@ -564,11 +560,11 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         }
 
         var allAlive = true;
-        var query = EntityQueryEnumerator<NukeopsRoleComponent, MindContainerComponent, MobStateComponent>();
-        while (query.MoveNext(out var nukeopsUid, out _, out var mindContainer, out var mobState))
+        var query = EntityQueryEnumerator<NukeopsRoleComponent, MindComponent, MobStateComponent>(); // Imperial Space nukeops-fix
+        while (query.MoveNext(out var nukeopsUid, out _, out var mind, out var mobState))
         {
             // mind got deleted somehow so ignore it
-            if (!_mind.TryGetMind(nukeopsUid, out _, out var mind, mindContainer))
+            if (mind == null) // Imperial Space nukeops-fix
                 continue;
 
             // check if player got gibbed or ghosted or something - count as dead


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## О ПР`е
Исправлен баг с ядерами в манифесте. Теперь в манифесте корректно отображаются их имена и состояние команды на конец раунда. 

## Технические детали
Теперь все компоненты антагов хранятся не в MindContainerComponent, а непосредственно в MindComponent, поэтому EntityQueryEnumerator не мог найти сущность с компонентом ядеров.