### PR TITLE
Фикс БСС прыжков

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -38,7 +38,7 @@ public sealed partial class ShuttleSystem
     public const float DefaultTravelTime = 20f;
     public const float DefaultArrivalTime = 5f;
     private const float FTLCooldown = 10f;
-    public const float FTLMassLimit = 300f;
+    public const float FTLMassLimit = 600f; // Изменено Imperial Space. По стандарту значение 300
 
     // I'm too lazy to make CVars.
 


### PR DESCRIPTION
## Об этом ПР'е:
Небольшой фикс прыжков БСС шаттлов, чтобы они могли прыгать даже с большой массой

## Почему/баланс:
Некоторые наши огромные шаттлы не могли в БСС прыжки. 

## Технические детали:
`FTL limit` для шаттлов поднят с массы в 300 единиц до 600. 