### PR TITLE
Маленькие баг фиксы

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/tiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/tiles.yml
@@ -199,6 +199,10 @@
       - FloorReinforced
   - type: Stack
     stackType: FloorTileReinforced
+  #Imperial craft tiles
+  - type: Construction
+    graph: TileReinforced
+    node: reinforcedtile
 
 # TODO add a catwalk tile item once tile smoothing is supported
 

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -95,7 +95,7 @@
 
 - type: stealTargetGroup
   id: HeadCloak
-  name: головной убор (любой)
+  name: плащ главы (любой)
   sprite:
     sprite: Clothing/Neck/Cloaks/cap.rsi
     state: icon


### PR DESCRIPTION
## Об этом ПР'е:
Исправлен тайл укрепленной плитки. Поправил локализацию в задании вора на кражу плащей глав

## Почему/баланс:
При крафте укрепленной плитки у людей напрочь ломался крафт других предметов. Ну а кривая локализация вводила игроков в заблуждение.

## Технические детали:
- Добавлен компонент `Construction` к укрепленной плитке, чтобы адекватно работала целевая нода. 
- Изменен перевод в задании вора на корректный с "головной убор" на "плащ главы"