### PR TITLE
Фикс дюпа стекла

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/computer.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/computer.yml
@@ -136,7 +136,7 @@
           completed:
             - !type:SpawnPrototype
               prototype: ShardGlass
-              amount: 2
+              amount: 1 ## Изменено Imperial Space. По стандарту стоит 2 стеклянных шарда. Для избежания дюпов
           steps:
             - tool: Prying
               doAfter: 2


### PR DESCRIPTION
## Об этом ПР'е:
Изменено количество выпадающих со сломанного компьютера осколков стекла с 2 на 1.

## Почему/баланс:
Служило способом дюпа стекла.

## Технические детали:
У `ComputerBroken` изменено количество осколков стекла с 2 на 1. 