### PR TITLE
Deleteborgmodule

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -726,7 +726,7 @@
   categories:
   - UplinkDisruption
 
-# - type: listing 
+# - type: listing // Вырезано Imperial Space, так как наши борги не работают с этим
 #   id: UplinkSyndicateWeaponModule
 #   name: uplink-syndicate-weapon-module-name
 #   description: uplink-syndicate-weapon-module-desc

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -726,15 +726,15 @@
   categories:
   - UplinkDisruption
 
-- type: listing
-  id: UplinkSyndicateWeaponModule
-  name: uplink-syndicate-weapon-module-name
-  description: uplink-syndicate-weapon-module-desc
-  productEntity: BorgModuleSyndicateWeapon
-  cost:
-    Telecrystal: 5
-  categories:
-  - UplinkDisruption
+# - type: listing 
+#   id: UplinkSyndicateWeaponModule
+#   name: uplink-syndicate-weapon-module-name
+#   description: uplink-syndicate-weapon-module-desc
+#   productEntity: BorgModuleSyndicateWeapon
+#   cost:
+#     Telecrystal: 5
+#   categories:
+#   - UplinkDisruption
 
 - type: listing
   id: UplinkSoapSyndie


### PR DESCRIPTION
## Об этом ПР'е:
Удален оружейный модуль киборга из аплинка

## Почему/баланс:
Это модуль ванильных боргов визардов. На наших боргов не работает

## Технические детали: 
Закомментирована строчка о боевом модуле киборга с указанием о причине удаления