### PR TITLE
Фикс фикса с фиксом фикса зомби

### DIFF
--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -32,6 +32,9 @@ using Robust.Shared.Physics.Events;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+// Imperial Space zombie-fix Imports Start
+using Content.Shared.Prying.Systems;
+// Imperial Space zombie-fix Imports End
 
 namespace Content.Server.Electrocution;
 
@@ -82,6 +85,7 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
         SubscribeLocalEvent<ElectrifiedComponent, AttackedEvent>(OnElectrifiedAttacked);
         SubscribeLocalEvent<ElectrifiedComponent, InteractHandEvent>(OnElectrifiedHandInteract);
         SubscribeLocalEvent<ElectrifiedComponent, InteractUsingEvent>(OnElectrifiedInteractUsing);
+        SubscribeLocalEvent<ElectrifiedComponent, PryingEvent>(OnPrying); // Imperial Space zombie-fix
         SubscribeLocalEvent<RandomInsulationComponent, MapInitEvent>(OnRandomInsulationMapInit);
         SubscribeLocalEvent<PoweredLightComponent, AttackedEvent>(OnLightAttacked);
 
@@ -172,6 +176,15 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
             TryDoElectrifiedAct(uid, args.OtherEntity, 1, electrified);
     }
 
+    // Imperial Space zombie-fix Start
+    private void OnPrying(EntityUid uid, ElectrifiedComponent electrified, PryingEvent args)
+    {
+        if (!electrified.OnBump) return;
+
+        args.Cancel();
+        TryDoElectrifiedAct(uid, args.User, 1, electrified);
+    }
+    // Imperial Space zombie-fix Imports End
     private void OnElectrifiedAttacked(EntityUid uid, ElectrifiedComponent electrified, AttackedEvent args)
     {
         if (!electrified.OnAttacked)

--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -181,10 +181,10 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
     {
         if (!electrified.OnBump) return;
 
-        args.Cancel();
         TryDoElectrifiedAct(uid, args.User, 1, electrified);
     }
     // Imperial Space zombie-fix Imports End
+
     private void OnElectrifiedAttacked(EntityUid uid, ElectrifiedComponent electrified, AttackedEvent args)
     {
         if (!electrified.OnAttacked)

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -39,6 +39,13 @@ public sealed class PryingSystem : EntitySystem
         if (args.Handled)
             return;
 
+        // Imperial Space zombie-fix Start
+        var ev = new PryingEvent(args.User);
+
+        RaiseLocalEvent(uid, ev);
+
+        if (ev.Cancelled) return;
+        // Imperial Space  zombie-fix End
         args.Handled = TryPry(uid, args.User, out _, args.Used);
     }
 
@@ -54,7 +61,17 @@ public sealed class PryingSystem : EntitySystem
         {
             Text = Loc.GetString("door-pry"),
             Impact = LogImpact.Low,
-            Act = () => TryPry(uid, args.User, out _, args.User),
+            Act = () =>
+            {
+                // Imperial Space zombie-fix Start
+                var ev = new PryingEvent(args.User);
+
+                RaiseLocalEvent(uid, ev);
+
+                if (ev.Cancelled) return;
+                // Imperial Space  zombie-fix End
+                TryPry(uid, args.User, out _, args.User);
+            }
         });
     }
 

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -44,7 +44,6 @@ public sealed class PryingSystem : EntitySystem
 
         RaiseLocalEvent(uid, ev);
 
-        if (ev.Cancelled) return;
         // Imperial Space  zombie-fix End
         args.Handled = TryPry(uid, args.User, out _, args.Used);
     }
@@ -68,7 +67,6 @@ public sealed class PryingSystem : EntitySystem
 
                 RaiseLocalEvent(uid, ev);
 
-                if (ev.Cancelled) return;
                 // Imperial Space  zombie-fix End
                 TryPry(uid, args.User, out _, args.User);
             }

--- a/Content.Shared/Prying/events/PryingEvent.cs
+++ b/Content.Shared/Prying/events/PryingEvent.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared.Prying.Systems;
+
+
+public sealed class PryingEvent(EntityUid user) : CancellableEntityEventArgs
+{
+    public EntityUid User = user;
+}

--- a/Content.Shared/Prying/events/PryingEvent.cs
+++ b/Content.Shared/Prying/events/PryingEvent.cs
@@ -1,7 +1,7 @@
 namespace Content.Shared.Prying.Systems;
 
 
-public sealed class PryingEvent(EntityUid user) : CancellableEntityEventArgs
+public sealed class PryingEvent(EntityUid user) : EventArgs
 {
     public EntityUid User = user;
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## О ПР`е
Фикс фикса с фиксом фикса зомби

## Технические детали
Мне показалось, что отменять ивент в Electrocutionsystem - это отличная идея, хотя сама проверка на наличие питания/изолей и т. д. находится дальше. Поэтому DoAfter с открытием двери всегда отменялся. Я просто заменил ивент на обычный, так как при поражении током DoAfter все равно собьется.