### PR TITLE
Небольшие изменения Офицера Спецопераций и его снаряжения

### DIFF
--- a/Resources/Prototypes/Imperial/Special Officer/SpecialOfficerClothes.yml
+++ b/Resources/Prototypes/Imperial/Special Officer/SpecialOfficerClothes.yml
@@ -40,11 +40,6 @@
   - type: Clothing
     sprite: Clothing/Shoes/Boots/jackboots.rsi
   - type: Matchbox
-  - type: Storage
-    whitelist:
-      tags:
-        - Knife
-        - Sidearm
   - type: FootstepModifier
     footstepSoundCollection:
       collection: FootstepSpecialOfficer

--- a/Resources/Prototypes/Imperial/Special Officer/SpecialOfficerSpawner.yml
+++ b/Resources/Prototypes/Imperial/Special Officer/SpecialOfficerSpawner.yml
@@ -27,6 +27,7 @@
       prototypes: [ SpecialOfficerGear ]
     - type: RandomHumanoidAppearance
       randomizeName: false
+    - type: MindShield
 
 - type: dataset ## Датасет, чтобы ОСО начинался с офицер
   id: SpecialOfficerName

--- a/Resources/Prototypes/Imperial/Special Officer/SpecialOfficerSpawner.yml
+++ b/Resources/Prototypes/Imperial/Special Officer/SpecialOfficerSpawner.yml
@@ -28,6 +28,9 @@
     - type: RandomHumanoidAppearance
       randomizeName: false
     - type: MindShield
+    - type: NpcFactionMember
+      factions:
+      - DeathSquad # Кастомная фракция Imperial Space
 
 - type: dataset ## Датасет, чтобы ОСО начинался с офицер
   id: SpecialOfficerName


### PR DESCRIPTION
## О ПРе
Исправлены ботинки ОСО, больше они не имеют компонент хранилища, использующийся у подобной обуви до апстрима. Сама сущность ОСО при появлении теперь сразу обладает имплантом МЩ и принадлежит к фракции Эскадрона.

## Подробнее о ботинках
С апстримом были упрощён прототип ботинок с слотом личного оружия: вместо компонента хранилища с вайтлистом теперь используется компонент слота для предмета с аналогичным белым списком. Однако, ботинкам ОСО в своём прототипе зачем-то также присваивался компонент хранилища, несмотря на то, что те уже имели его от парента, в котором тот, соответственно, был заменён на компонент ItemSlots с апстримом. В связи с этим компонент хранилища и был удалён из файла прототипа. 

## По какой причине?
С целью исправить небольшие косяки в прототипе и облегчить жизнь ГеймМастерам и участникам ивентов, занявшим данную роль. Ботинки больше не будут вводить в заблуждение, имплант МЩ не даст завербовать ОСО в революцию/стать ему другим антагом, зависимым от отсутствия импланта, а присвоение фракции приведет к тому, что турели ЭС и Апокрифический Р.И.Г. больше не будут триггериться на него.