### PR TITLE
Сделать датчики костюма переключенными в режим координат раундстартом

### DIFF
--- a/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class SuitSensorComponent : Component
     ///     Choose a random sensor mode when item is spawned.
     /// </summary>
     [DataField("randomMode")]
-    public bool RandomMode = true;
+    public bool RandomMode = false;
 
     /// <summary>
     ///     If true user can't change suit sensor mode
@@ -27,7 +27,7 @@ public sealed partial class SuitSensorComponent : Component
     ///     Current sensor mode. Can be switched by user verbs.
     /// </summary>
     [DataField("mode")]
-    public SuitSensorMode Mode = SuitSensorMode.SensorOff;
+    public SuitSensorMode Mode = SuitSensorMode.SensorCords;
 
     /// <summary>
     ///     Activate sensor if user wear it in this slot.


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
ПР делает все костюмы экипажа автоматически переключенными в режим координат.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Многие забывают переключать датчики в режим координат, бедный парамедик и бедный труп забывчивого человека страдают. А те, кому датчики костюма не так сильно нужны, могут их переключить в режим, который им нужен