### PR TITLE
Плащ ГСБ теперь цель вора

### DIFF
--- a/Resources/Prototypes/Imperial/ImperialClothes/ImperialCloak.yml
+++ b/Resources/Prototypes/Imperial/ImperialClothes/ImperialCloak.yml
@@ -15,6 +15,9 @@
   components:
   - type: Sprite
     sprite: Imperial/ImperialClothes/hoscloakformal.rsi
+  - type: StealTarget
+    stealGroup: HeadCloak
+
 
 - type: entity
   parent: ClothingNeckBase


### PR DESCRIPTION
## Об этом ПР'е:
Фикс бага с плащом ГСБ. Теперь он является целью вора.

## Почему/баланс:
Так как формальный плащ ГСБ является нашей разработкой, то и в целях вора он не был прописан. 

## Технические детали:
Добавил компонент `StealTarget` плащу ГСБ. Теперь ворам будет его засчитывать. 