### PR TITLE
Фикс амуниционного техфаба

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -782,6 +782,7 @@
       whitelist:
         tags:
           - Sheet
+          - Ingot # Fix Imperial Space. Сделано, чтобы можно было печатать транквилизаторные патроны
 
 - type: entity
   id: MedicalTechFab


### PR DESCRIPTION
## Об этом ПР'е:
В вайтлист ресурсов техфаба патронов добавлены слитки для печати особенных патронов.

## Почему/баланс:
Видимо при изменении крафта транквилизаторных патронов забыли, что есть техфаб патронов, в котором также можно их печатать. А у него не было вайтлиста на слитки. Отсюда выходило, что крафт патронов в нем есть, а ресурсы положить для крафта нельзя. Это исправляет данную проблему

## Технические детали:
Добавлен ресурс `Ingot` в вайтлист техфаба патронов. Теперь он может кушать золотые и серебряные слитки