### PR TITLE
Фикс распознавания плащей как цели вора

### DIFF
--- a/Resources/Prototypes/Imperial/CaptainExtraDrip/clothing.yml
+++ b/Resources/Prototypes/Imperial/CaptainExtraDrip/clothing.yml
@@ -143,6 +143,8 @@
   components:
   - type: Sprite
     sprite: Imperial/CaptainExtraDrip/white/capwhitecloack.rsi
+  - type: StealTarget
+    stealGroup: HeadCloak
 
 - type: entity
   id: Capwhitebackpack
@@ -161,6 +163,8 @@
   components:
   - type: Sprite
     sprite: Imperial/CaptainExtraDrip/sheriff/capsheriffcloack.rsi
+  - type: StealTarget
+    stealGroup: HeadCloak
 
 - type: entity
   id: CapSheriffbackpack

--- a/Resources/Prototypes/Imperial/ImperialClothes/ImperialCloak.yml
+++ b/Resources/Prototypes/Imperial/ImperialClothes/ImperialCloak.yml
@@ -15,6 +15,8 @@
   components:
   - type: Sprite
     sprite: Imperial/ImperialClothes/hoscloakformal.rsi
+  - type: StealTarget
+    stealGroup: HeadCloak
 
 - type: entity
   parent: ClothingNeckBase


### PR DESCRIPTION
## Об этом ПР'е:
Теперь торжественный плащ ГСБ, альтернативные плащи капитана из кэпомата воспринимаются как цели вора. 

## Почему/баланс:
Наши альтернативные предметы одежды при краже ворами не засчитывались

## Технические детали:
Добавлен компонент `StealTarget` к белому плащу капитана, к плащу шерифа, к торжественному плащу ГСБ. Ванильные файлы не затронуты. 