### PR TITLE
Craftable medipens

### DIFF
--- a/Resources/Locale/ru-RU/Imperial/CraftableMedipens/medipens.ftl
+++ b/Resources/Locale/ru-RU/Imperial/CraftableMedipens/medipens.ftl
@@ -1,0 +1,6 @@
+ent-SmallPrototypeChemicalMedipen = прототипный медипен
+  .desc = Прототип экстренного медипена с функцией долива реагентов.
+ent-NormalPrototypeChemicalMedipen = прототипный медипен увеличенного объёма
+  .desc = За счёт использования серебра в его конструкции позволяет вмещать большее количество реагентов.
+
+research-technology-prototypes-medipens = Прототипные автоинжекторы

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -850,6 +850,8 @@
       - BluespaceBeaker
       - SyringeBluespace
       - SyringeCryostasis
+      - SmallPrototypeChemicalMedipen ### Imperial craftable medipens
+      - NormalPrototypeChemicalMedipen ### Imperial craftable medipens
   - type: Machine
     board: MedicalTechFabCircuitboard
   - type: StealTarget

--- a/Resources/Prototypes/Imperial/PrototypeMedipens/prototype-hypopens.yml
+++ b/Resources/Prototypes/Imperial/PrototypeMedipens/prototype-hypopens.yml
@@ -1,0 +1,73 @@
+- type: entity
+  name: small prototype medipen
+  parent: BaseItem
+  description: A sterile injector for rapid administration of drugs to patients. Now can be refilled!
+  id: SmallPrototypeChemicalMedipen
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Medical/medipen.rsi
+    layers:
+    - state: medipen
+      map: ["enum.SolutionContainerLayers.Fill"]
+  - type: SolutionContainerVisuals
+    maxFillLevels: 1
+    changeColor: false
+    emptySpriteName: medipen_empty
+  - type: SolutionContainerManager
+    solutions:
+      pen:
+        maxVol: 7.5
+  - type: Hypospray
+    canPenetrate: false
+    solutionName: pen
+    transferAmount: 7.5
+  - type: RefillableSolution
+    solution: pen
+  - type: UseDelay
+    delay: 7.5
+
+- type: entity
+  name: extra spaced prototype medipen
+  parent: SmallPrototypeChemicalMedipen
+  description: A sterile injector for rapid administration of drugs to patients with extra space for chemicals. Now can be refilled!
+  id: NormalPrototypeChemicalMedipen
+  components:
+  - type: Hypospray
+    solutionName: pen
+    transferAmount: 15
+  - type: SolutionContainerManager
+    solutions:
+      pen:
+        maxVol: 15
+
+- type: latheRecipe
+  id: SmallPrototypeChemicalMedipen
+  result: SmallPrototypeChemicalMedipen
+  category: Tools
+  completetime: 5
+  materials:
+    Steel: 500
+    Plastic: 750
+
+- type: latheRecipe
+  id: NormalPrototypeChemicalMedipen
+  result: NormalPrototypeChemicalMedipen
+  category: Tools
+  completetime: 5
+  materials:
+    Steel: 750
+    Plastic: 1000
+    Silver: 200
+
+- type: technology
+  id: PrototypeMedipens
+  name: research-technology-prototypes-medipens
+  icon:
+    sprite: Objects/Specific/Medical/medipen.rsi
+    state: medipen
+  discipline: CivilianServices
+  tier: 2
+  cost: 7500
+  recipeUnlocks:
+  - SmallPrototypeChemicalMedipen
+  - NormalPrototypeChemicalMedipen

--- a/Resources/Prototypes/Imperial/PrototypeMedipens/prototype-hypopens.yml
+++ b/Resources/Prototypes/Imperial/PrototypeMedipens/prototype-hypopens.yml
@@ -16,11 +16,11 @@
   - type: SolutionContainerManager
     solutions:
       pen:
-        maxVol: 7.5
+        maxVol: 5
   - type: Hypospray
     canPenetrate: false
     solutionName: pen
-    transferAmount: 7.5
+    transferAmount: 5
   - type: RefillableSolution
     solution: pen
   - type: UseDelay
@@ -34,11 +34,11 @@
   components:
   - type: Hypospray
     solutionName: pen
-    transferAmount: 15
+    transferAmount: 10
   - type: SolutionContainerManager
     solutions:
       pen:
-        maxVol: 15
+        maxVol: 10
 
 - type: latheRecipe
   id: SmallPrototypeChemicalMedipen


### PR DESCRIPTION
## About the PR
Добавляет крафтабельные медипены как т2 технологию для РНД.

## Why / Balance
Гипоспреи уже давно не доминируют из-за невозможности пробивать скафы, поэтому дать пополняемые медипены как т2 технологию самой редко изучаемой ветки не кажется имбалансной темой.

## Technical details
Медипены имеют кд 7.5 при использовании, чтобы их не использовали как гипоспрей.

![автопены](https://github.com/user-attachments/assets/c1d67f66-c78c-4e9d-8692-ad58d7c9c374)

