### PR TITLE
NukeEvacBonusBlock

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -92,6 +92,12 @@ public sealed partial class NukeopsRuleComponent : Component
     [DataField]
     public TimeSpan WarNukieArriveDelay = TimeSpan.FromMinutes(15);
 
+    // Imperial Space Start
+    // Данное значение добавляет задержку к вызову эвакуационного шаттла после объявления войны
+    [DataField]
+    public TimeSpan WarEvacBonusBlock = TimeSpan.FromMinutes(10);
+    // Imperial Space End
+
     /// <summary>
     ///     Minimal operatives count for war declaration
     /// </summary>

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -405,7 +405,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
             {
                 // Nukies must wait some time after declaration of war to get on the station
                 var warTime = Timing.CurTime.Subtract(nukeops.WarDeclaredTime.Value);
-                if (warTime < nukeops.WarNukieArriveDelay)
+                if (warTime < nukeops.WarNukieArriveDelay + nukeops.WarEvacBonusBlock) /// Изменено Imperial Space. nukeops.WarEvacBonusBlock - дополнительное значение, блокирующее эвак на бонусные 10 минут
                 {
                     ev.Cancelled = true;
                     ev.Reason = Loc.GetString("war-ops-shuttle-call-unavailable");


### PR DESCRIPTION
## Об этом ПР'е:
Добавлена бонусная блокировка вызова эвака у станции после объявления войны со стороны ЯО.

## Почему/баланс:
Так как недавно была удалена коммуникационная консоль синдиката с одного нашего шаттла, встал вопрос о том, не будут ли вызывать на станции эвак очень быстро, не давая ЯО даже шаг сделать на станции. Возможности отзыва эвака у ЯО быть не должно по стандарту, однако увеличить им время блокировки ничто не мешает

## Технические детали:
- Введен новый параметр `WarEvacBonusBlock`, которому присвоено значение в 10 минут (можно менять в зависимости от нужд)
- В переменную, проверяющую, можно ли вызвать эвак на станции, добавлена переменная. Ранее было: 
`warTime < nukeops.WarNukieArriveDelay`, теперь: `warTime < nukeops.WarNukieArriveDelay + nukeops.WarEvacBonusBlock`

## Как оно работает? 
После объявления войны переменной WarTime присваивается значение `0`. WarNukieArriveDelay всегда одинакова, и имеет значение в `15` минут. Она определяет, сколько ЯО должны стоять на своем аванпосте (сколько им заблокирован вылет) и через какое время у станции будет возможность вызвать эвак. Сейчас это будет так:

0 < 15 (WarNukieArriveDelay) + 10 (WarEvacBonusBlock) . То есть ЯО смогут вылететь со своего аванпоста через 15 минут после объявления войны, а станция сможет вызвать эвак только через 25 минут после объявления войны