### PR TITLE
Был добавлен UseDelay к арбалету.

### DIFF
--- a/Resources/Prototypes/Imperial/MiniCrossbow/battery_guns.yml
+++ b/Resources/Prototypes/Imperial/MiniCrossbow/battery_guns.yml
@@ -1,4 +1,3 @@
-
 - type: entity
   name: energy-crossbow
   parent: BaseWeaponBatterySmall
@@ -41,3 +40,6 @@
     steps: 2
     zeroVisible: true
   - type: Appearance
+  - type: UseDelayOnShoot
+  - type: UseDelay
+    delay: 4

--- a/Resources/Prototypes/Imperial/MiniCrossbow/battery_guns.yml
+++ b/Resources/Prototypes/Imperial/MiniCrossbow/battery_guns.yml
@@ -30,7 +30,9 @@
     rechargeCooldown: 4
     rechargeSound:
       path: /Audio/Weapons/drawbow2.ogg
+  - type: UseDelayOnShoot
   - type: UseDelay
+    delay: 4
   - type: BasicEntityAmmoProvider
     proto: BulletCrossbow
     capacity: 1
@@ -40,6 +42,3 @@
     steps: 2
     zeroVisible: true
   - type: Appearance
-  - type: UseDelayOnShoot
-  - type: UseDelay
-    delay: 4


### PR DESCRIPTION
## О чём PR
Был добавлен UseDelay к энерго-арбалету, проще говоря полосочка что указана внизу в медиа.

## Почему / Баланс
Ну типо, онли визуал и позволит чуть лучше контролить арбалет.

## Медиа
![изображение](https://github.com/user-attachments/assets/acb18160-921d-4e5d-9eca-3b4141e2a69d)
