### PR TITLE
ChristmasAntag: hot-fix, added find target spell

### DIFF
--- a/Content.Server/Imperial/ChristmasAntag/BecomeChristmasAntagConditionSystem.cs
+++ b/Content.Server/Imperial/ChristmasAntag/BecomeChristmasAntagConditionSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Imperial.ChristmasAntag.Components;
 using Content.Shared.Objectives.Components;
 using Content.Shared.Mind;
 using Robust.Shared.Random;
+using Content.Shared.NukeOps;
 
 namespace Content.Server.Imperial.ChristmasAntag
 {
@@ -51,7 +52,9 @@ namespace Content.Server.Imperial.ChristmasAntag
                 return;
             }
 
-            var potentialTargets = allHumans.Where(mind => !IsChristmasAntag(mind)).ToList();
+            var potentialTargets = allHumans.Where(mind => !IsChristmasAntag(mind)
+                                                        && !IsNukeOpsAntag(mind)
+                                                        && !IsLoneNukeOpsAntag(mind)).ToList();
             if (potentialTargets.Count == 0)
             {
                 args.Cancelled = true;
@@ -65,9 +68,26 @@ namespace Content.Server.Imperial.ChristmasAntag
         public bool IsChristmasAntag(EntityUid mindId)
         {
             if (!_role.MindHasRole<ChristmasAntagRoleComponent>(mindId))
-            {
                 return false;
-            }
+
+            return true;
+        }
+
+        public bool IsNukeOpsAntag(EntityUid mindId)
+        {
+            if (!_role.MindHasRole<NukeopsRoleComponent>(mindId))
+                return false;
+
+            return true;
+        }
+
+        public bool IsLoneNukeOpsAntag(EntityUid mindId)
+        {
+            if (!TryComp<MindComponent>(mindId, out var comp))
+                return false;
+
+            if (!HasComp<NukeOperativeComponent>(comp.CurrentEntity))
+                return false;
 
             return true;
         }

--- a/Content.Server/Imperial/ChristmasAntag/ChristmasAntagSystem.cs
+++ b/Content.Server/Imperial/ChristmasAntag/ChristmasAntagSystem.cs
@@ -70,7 +70,7 @@ public sealed class ChristmasAntagSystem : EntitySystem
     public void CursedGiftSmite(EntityUid target, ChristmasAntagComponent comp)
     {
         var sysMan = IoCManager.Resolve<IEntitySystemManager>();
-        sysMan.GetEntitySystem<ExplosionSystem>().QueueExplosion(target, "Default", 2, 2, 2);
+        sysMan.GetEntitySystem<ExplosionSystem>().QueueExplosion(target, "Default", 1, 1, 1);
         QueueDel(target);
         if (comp.LastCursedGift != null)
             EntityManager.DeleteEntity(comp.LastCursedGift);

--- a/Content.Server/Imperial/ChristmasAntag/Components/CurseGiftComponent.cs
+++ b/Content.Server/Imperial/ChristmasAntag/Components/CurseGiftComponent.cs
@@ -9,7 +9,7 @@ public sealed partial class CurseGiftComponent : Component
     public TimeSpan CurseDelay = TimeSpan.FromSeconds(5);
 
     [DataField]
-    public List<EntProtoId> GiftGoal = new() { "PresentRandomInsane" };
+    public List<EntProtoId> GiftGoal = new() { "PresentRandomUnsafeNG3" };
 
     [DataField]
     public EntityUid? CurseTargetEntity;

--- a/Content.Server/Imperial/ChristmasAntag/CurseGiftSystem.cs
+++ b/Content.Server/Imperial/ChristmasAntag/CurseGiftSystem.cs
@@ -94,7 +94,8 @@ public sealed class CurseGiftSystem : EntitySystem
             {
                 if (TryComp<MetaDataComponent>(action, out var metaComp))
                 {
-                    if (metaComp.EntityPrototype != null && metaComp.EntityPrototype.ID == "ActionSpawnCursedGift")
+                    if (metaComp.EntityPrototype != null && (metaComp.EntityPrototype.ID == "ActionSpawnCursedGift"
+                                                             || metaComp.EntityPrototype.ID == "ActionTryToFindTarget"))
                     {
                         _actionsSystem.RemoveAction(action);
                     }
@@ -120,10 +121,40 @@ public sealed class CurseGiftSystem : EntitySystem
 
         if (TryComp<ChristmasAntagComponent>(args.User, out var userComp) && args.User == component.OwnerGift && userComp.Target != null)
         {
-            _chat.TrySendInGameICMessage(component.Owner, Loc.GetString("cursed-gift-say-timer") + $" {userComp.CurseTimer.Minutes} минут и {userComp.CurseTimer.Seconds} секунд!", InGameICChatType.Speak, true);
+            int minutes = userComp.CurseTimer.Minutes;
+            int seconds = userComp.CurseTimer.Seconds;
+
+            string GetMinuteWord(int minute)
+            {
+                if (minute % 10 == 1 && minute % 100 != 11)
+                    return "минута";
+                else if (minute % 10 >= 2 && minute % 10 <= 4 && (minute % 100 < 10 || minute % 100 >= 20))
+                    return "минуту";
+                else
+                    return "минут";
+            }
+
+            string GetSecondWord(int second)
+            {
+                if (second % 10 == 1 && second % 100 != 11)
+                    return "секунда";
+                else if (second % 10 >= 2 && second % 10 <= 4 && (second % 100 < 10 || second % 100 >= 20))
+                    return "секунду";
+                else
+                    return "секунд";
+            }
+
+            string minuteWord = GetMinuteWord(minutes);
+            string secondWord = GetSecondWord(seconds);
+
+            _chat.TrySendInGameICMessage(component.Owner,
+                Loc.GetString("cursed-gift-say-timer") + $" {minutes} {minuteWord} и {seconds} {secondWord}!",
+                InGameICChatType.Speak, true);
+
             _delay.TryResetDelay((component.Owner, useDelay));
             return;
         }
+
 
         _chat.TrySendInGameICMessage(component.Owner, Loc.GetString("cursed-gift-say-no-target"), InGameICChatType.Speak, true);
         _delay.TryResetDelay((component.Owner, useDelay));

--- a/Content.Shared/Imperial/ChristmasAntag/Events/TryToFindTargetSpellEvent.cs
+++ b/Content.Shared/Imperial/ChristmasAntag/Events/TryToFindTargetSpellEvent.cs
@@ -1,0 +1,8 @@
+using Content.Shared.Actions;
+
+namespace Content.Shared.Imperial.ChristmasAntag.Events
+{
+    public sealed partial class TryToFindTargetSpellEvent : InstantActionEvent
+    {
+    }
+}

--- a/Resources/Prototypes/Imperial/ChristmasAntag/actions.yml
+++ b/Resources/Prototypes/Imperial/ChristmasAntag/actions.yml
@@ -24,10 +24,24 @@
     useDelay: 60
     itemIconStyle: BigAction
     icon:
-      sprite: Objects/Decoration/present.rsi
-      state: present
+      sprite: Imperial/NG/presents.rsi
+      state: present2
     event: !type:SpawnAshGiftSpellEvent
-    
+
+- type: entity
+  id: ActionTryToFindTarget
+  name: Найти цель
+  description: Сообщает Вам расстояние до Вашей цели
+  noSpawn: true
+  components:
+  - type: InstantAction
+    useDelay: 1
+    itemIconStyle: BigAction
+    icon:
+      sprite: Objects/Devices/pinpointer.rsi
+      state: pinpointer-crewprox
+    event: !type:TryToFindTargetSpellEvent
+
 - type: polymorph
   id: CursedGiftSmite
   configuration:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

**Changelog**
- Добавлена способность для поиска цели;
- Добавлены исключения при выборе цели: ядерные оперативники в секрете и одинокий ядерный оперативник больше не могут стать целью антагониста;
- Обновлено склонение слов 'минуты' и 'секунды' при отображении оставшегося до превращения времени;
- Обновлены прототипы подарков создаваемых, после превращения в проклятый подарок, а также после выполнения цели;
- Удалены  "бросания" окружающий предметов при использовании способности спавна подарков антагонистом.
